### PR TITLE
Attempt to fix `freebsd` in Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -128,7 +128,7 @@ freebsd_task:
   name: test (freebsd - 3.9)
   freebsd_instance: {image_family: freebsd-13-1}
   install_script:
-    - portsnap cron update
+    - portsnap auto
     - pkg update -f
     - pkg remove -y python lang/python
     - pkg install -y git python39 py39-pip py39-gdbm py39-sqlite3 py39-tox py39-pipx

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -128,6 +128,7 @@ freebsd_task:
   name: test (freebsd - 3.9)
   freebsd_instance: {image_family: freebsd-13-1}
   install_script:
+    - pkg update -f
     - pkg remove -y python lang/python
     - pkg install -y git python39 py39-pip py39-gdbm py39-sqlite3 py39-tox
     - ln -s /usr/local/bin/python3.9 /usr/local/bin/python

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -128,17 +128,21 @@ freebsd_task:
   name: test (freebsd - 3.9)
   freebsd_instance: {image_family: freebsd-13-1}
   install_script:
-    - portsnap auto --interactive
-    - pkg update -f
-    # Inspect freebsd port
-    - cat /usr/ports/devel/py-pipx/Makefile
-    # help
-    - pkg install --help
-    - pkg install --add
     - pkg remove -y python lang/python
-    - pkg install -y git python39 py39-pip py39-gdbm py39-sqlite3 py39-tox py39-pipx
+    - pkg install -y git python39 py39-pip py39-gdbm py39-sqlite3 py39-tox
     - ln -s /usr/local/bin/python3.9 /usr/local/bin/python
-    - pkg info pipx
+    # Install pipx from source since the latest pre-compiled version is outdated.
+    # Obs.: Probably it is safe to install py39-pipx directly after Oct/2022.
+    - pkg update -f
+    # - portsnap auto --interactive
+    #   # Unfortunatelly we cannot ommit the `--interactive` config here,
+    #   # otherwise the random delay can be too big to afford.
+    #   # On the bright side, the CI should run on demand, so the likely hood
+    #   # of multiple jobs hitting the FreeBSD server at the same time is small.
+    - cd /usr/ports/devel/py-pipx
+    - cat Makefile
+    - make -DPY_FLAVOR=3.9
+    - make -DPY_FLAVOR=3.9 install clean
   <<: *test-template
 
 # windows_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -138,7 +138,7 @@ freebsd_task:
     - pkg update -f
     - pkg search pipx
     - pkg search -o pipx
-    - pkg install -y py39-pipx-1.1.0_1
+    - pkg install -y py39-pipx-1.1.0
     # # Install pipx from source since the latest pre-compiled version is outdated.
     # # Obs.: Probably it is safe to install py39-pipx directly after Oct/2022.
     # - portsnap fetch --interactive

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -127,6 +127,10 @@ build_task:
 freebsd_task:
   name: test (freebsd - 3.9)
   freebsd_instance: {image_family: freebsd-13-1}
+  env:  # Obs.: Only required to build pipx
+    PY_FLAVOR: 3.9
+    FLAVOR: py39
+    DEFAULT_VERSIONS: python=3.9 python3=3.9
   install_script:
     - pkg remove -y python lang/python
     - pkg install -y git python39 py39-pip py39-gdbm py39-sqlite3 py39-tox
@@ -141,10 +145,8 @@ freebsd_task:
     - portsnap extract devel/py-pipx
     - cd /usr/ports/devel/py-pipx
     - cat Makefile
-    - sed -i .bkp 's/python:3.6+/python:3.9/' Makefile
-    - cat Makefile
-    - make PY_FLAVOR=3.9 FLAVOR=py39
-    - make PY_FLAVOR=3.9 FLAVOR=py39 reinstall clean
+    - make
+    - make reinstall clean
   <<: *test-template
 
 # windows_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -133,8 +133,12 @@ freebsd_task:
     - ln -s /usr/local/bin/python3.9 /usr/local/bin/python
     # Install pipx from source since the latest pre-compiled version is outdated.
     # Obs.: Probably it is safe to install py39-pipx directly after Oct/2022.
-    - cd /usr/ports/devel/
-    - make fetch
+    - portsnap fetch --interactive
+      # Unfortunatelly we cannot ommit the `--interactive` config here,
+      # otherwise the random delay can be too big to afford.
+      # On the bright side, the CI should run on demand, so the likely hood
+      # of multiple jobs hitting the FreeBSD server at the same time is small.
+    - portsnap extract devel/py-pipx
     - cd /usr/ports/devel/py-pipx
     - cat Makefile
     - make FLAVOR=py39

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -132,13 +132,17 @@ freebsd_task:
     FLAVOR: py39
     DEFAULT_VERSIONS: python=3.9 python3=3.9
   install_script:
+    # The pipx port for 2022Q3 is outdated/broken, we need the latest
+    - cp /etc/pkg/FreeBSD.conf /usr/local/etc/pkg/repos/FreeBSD.conf
+    - sed -i .bkp 's/quarterly/latest/' /usr/local/etc/pkg/repos/FreeBSD.conf
+    - cat /usr/local/etc/pkg/repos/FreeBSD.conf
     - pkg remove -y python lang/python
     - pkg install -y git python39 py39-pip py39-gdbm py39-sqlite3 py39-tox
     - ln -s /usr/local/bin/python3.9 /usr/local/bin/python
     - pkg update -f
     - pkg search pipx
     - pkg search -o pipx
-    - pkg install -y py39-pipx-1.1.0
+    - pkg install -y py39-pipx
     # # Install pipx from source since the latest pre-compiled version is outdated.
     # # Obs.: Probably it is safe to install py39-pipx directly after Oct/2022.
     # - portsnap fetch --interactive

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -133,6 +133,7 @@ freebsd_task:
     DEFAULT_VERSIONS: python=3.9 python3=3.9
   install_script:
     # The pipx port for 2022Q3 is outdated/broken, we need the latest
+    - mkdir -p /usr/local/etc/pkg/repos/
     - cp /etc/pkg/FreeBSD.conf /usr/local/etc/pkg/repos/FreeBSD.conf
     - sed -i .bkp 's/quarterly/latest/' /usr/local/etc/pkg/repos/FreeBSD.conf
     - cat /usr/local/etc/pkg/repos/FreeBSD.conf

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -140,8 +140,8 @@ freebsd_task:
       # of multiple jobs hitting the FreeBSD server at the same time is small.
     - cd /usr/ports/devel/py-pipx
     - cat Makefile
-    - make -DPY_FLAVOR=3.9
-    - make -DPY_FLAVOR=3.9 install clean
+    - make FLAVOR=py39
+    - make FLAVOR=py39 install clean
   <<: *test-template
 
 # windows_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -136,7 +136,7 @@ freebsd_task:
     - cd /usr/ports/devel/py-pipx
     - make fetch-recursive
     - make FLAVOR=py39
-    - make FLAVOR=py39 install clean
+    - make FLAVOR=py39 reinstall clean
   <<: *test-template
 
 # windows_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -128,7 +128,7 @@ freebsd_task:
   name: test (freebsd - 3.9)
   freebsd_instance: {image_family: freebsd-13-1}
   install_script:
-    - portsnap fetch --interactive update
+    - portsnap auto --interactive
     - pkg update -f
     - pkg remove -y python lang/python
     - pkg install -y git python39 py39-pip py39-gdbm py39-sqlite3 py39-tox py39-pipx

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -130,9 +130,15 @@ freebsd_task:
   install_script:
     - portsnap auto --interactive
     - pkg update -f
+    # Inspect freebsd port
+    - cat /usr/ports/devel/py-pipx/Makefile
+    # help
+    - pkg install --help
+    - pkg install --add
     - pkg remove -y python lang/python
     - pkg install -y git python39 py39-pip py39-gdbm py39-sqlite3 py39-tox py39-pipx
     - ln -s /usr/local/bin/python3.9 /usr/local/bin/python
+    - pkg info pipx
   <<: *test-template
 
 # windows_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -141,8 +141,8 @@ freebsd_task:
     - portsnap extract devel/py-pipx
     - cd /usr/ports/devel/py-pipx
     - cat Makefile
-    - make FLAVOR=py39
-    - make FLAVOR=py39 reinstall clean
+    - make PYTHON_PKGNAMEPREFIX=py39- FLAVOR=py39
+    - make PYTHON_PKGNAMEPREFIX=py39- FLAVOR=py39 reinstall clean
   <<: *test-template
 
 # windows_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -130,9 +130,8 @@ freebsd_task:
   install_script:
     - pkg update -f
     - pkg remove -y python lang/python
-    - pkg install -y git python39 py39-pip py39-gdbm py39-sqlite3 py39-tox
+    - pkg install -y git python39 py39-pip py39-gdbm py39-sqlite3 py39-tox py39-pipx
     - ln -s /usr/local/bin/python3.9 /usr/local/bin/python
-    - python -m pip install pipx  # workaround for py39-pipx
   <<: *test-template
 
 windows_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -133,12 +133,11 @@ freebsd_task:
     - ln -s /usr/local/bin/python3.9 /usr/local/bin/python
     # Install pipx from source since the latest pre-compiled version is outdated.
     # Obs.: Probably it is safe to install py39-pipx directly after Oct/2022.
-    - pkg update -f
-    # - portsnap auto --interactive
-    #   # Unfortunatelly we cannot ommit the `--interactive` config here,
-    #   # otherwise the random delay can be too big to afford.
-    #   # On the bright side, the CI should run on demand, so the likely hood
-    #   # of multiple jobs hitting the FreeBSD server at the same time is small.
+    - portsnap auto --interactive
+      # Unfortunatelly we cannot ommit the `--interactive` config here,
+      # otherwise the random delay can be too big to afford.
+      # On the bright side, the CI should run on demand, so the likely hood
+      # of multiple jobs hitting the FreeBSD server at the same time is small.
     - cd /usr/ports/devel/py-pipx
     - cat Makefile
     - make -DPY_FLAVOR=3.9

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -128,7 +128,7 @@ freebsd_task:
   name: test (freebsd - 3.9)
   freebsd_instance: {image_family: freebsd-13-1}
   install_script:
-    - portsnap fetch update
+    - portsnap cron update
     - pkg update -f
     - pkg remove -y python lang/python
     - pkg install -y git python39 py39-pip py39-gdbm py39-sqlite3 py39-tox py39-pipx

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -76,118 +76,113 @@ build_task:
   install_script: pip install tox
   build_script: tox -e clean,build
 
-# check_task:
-#   name: check (Linux - 3.10)
-#   alias: check
-#   depends_on: [build]
-#   container: {image: "python:3.10-bullseye"}  # most recent => better types
-#   dist_cache: {folder: dist, fingerprint_script: echo $CIRRUS_BUILD_ID}  # download
-#   <<: *task-template
-#   install_script: pip install pre-commit
-#   check_script:
-#     - pre-commit run --all-files --show-diff-on-failure --color always
-#     # - tox -e typecheck
+check_task:
+  name: check (Linux - 3.10)
+  alias: check
+  depends_on: [build]
+  container: {image: "python:3.10-bullseye"}  # most recent => better types
+  dist_cache: {folder: dist, fingerprint_script: echo $CIRRUS_BUILD_ID}  # download
+  <<: *task-template
+  install_script: pip install pre-commit
+  check_script:
+    - pre-commit run --all-files --show-diff-on-failure --color always
+    # - tox -e typecheck
 
-# linux_task:
-#   matrix:
-#     - name: test (Linux - 3.6)
-#       container: {image: "python:3.6-bullseye"}
-#       allow_failures: true  # EoL
-#     - name: test (Linux - 3.7)
-#       container: {image: "python:3.7-bullseye"}
-#     - name: test (Linux - 3.8)
-#       container: {image: "python:3.8-bullseye"}
-#     - name: test (Linux - 3.9)
-#       container: {image: "python:3.9-bullseye"}
-#     - name: test (Linux - 3.10)
-#       container: {image: "python:3.10-bullseye"}
-#     - name: test (Linux - 3.11)
-#       container: {image: "python:3.11-rc-bullseye"}
-#       allow_failures: true  # Experimental
-#   install_script:
-#     - python -m pip install --upgrade pip tox pipx
-#   <<: *test-template
+linux_task:
+  matrix:
+    - name: test (Linux - 3.6)
+      container: {image: "python:3.6-bullseye"}
+      allow_failures: true  # EoL
+    - name: test (Linux - 3.7)
+      container: {image: "python:3.7-bullseye"}
+    - name: test (Linux - 3.8)
+      container: {image: "python:3.8-bullseye"}
+    - name: test (Linux - 3.9)
+      container: {image: "python:3.9-bullseye"}
+    - name: test (Linux - 3.10)
+      container: {image: "python:3.10-bullseye"}
+    - name: test (Linux - 3.11)
+      container: {image: "python:3.11-rc-bullseye"}
+      allow_failures: true  # Experimental
+  install_script:
+    - python -m pip install --upgrade pip tox pipx
+  <<: *test-template
 
-# mamba_task:
-#   name: test (Linux - mambaforge)
-#   container: {image: "condaforge/mambaforge"}
-#   install_script:  # Overwrite template
-#     - mamba install -y pip tox pipx
-#   <<: *test-template
+mamba_task:
+  name: test (Linux - mambaforge)
+  container: {image: "condaforge/mambaforge"}
+  install_script:  # Overwrite template
+    - mamba install -y pip tox pipx
+  <<: *test-template
 
-# macos_task:
-#   name: test (macOS - brew)
-#   macos_instance: {image: "big-sur-xcode"}
-#   brew_cache: {folder: "$HOME/Library/Caches/Homebrew"}
-#   install_script: brew install python tox pipx
-#   env:
-#     PATH: "/usr/local/opt/python/libexec/bin:${PATH}"
-#   <<: *test-template
+macos_task:
+  name: test (macOS - brew)
+  macos_instance: {image: "big-sur-xcode"}
+  brew_cache: {folder: "$HOME/Library/Caches/Homebrew"}
+  install_script: brew install python tox pipx
+  env:
+    PATH: "/usr/local/opt/python/libexec/bin:${PATH}"
+  <<: *test-template
 
 freebsd_task:
   name: test (freebsd - 3.9)
   freebsd_instance: {image_family: freebsd-13-1}
-  env:  # Obs.: Only required to build pipx
-    PY_FLAVOR: 3.9
-    FLAVOR: py39
-    DEFAULT_VERSIONS: python=3.9 python3=3.9
   install_script:
-    # The pipx port for 2022Q3 is outdated/broken, we need the latest
     - pkg remove -y python lang/python
-    - pkg install -y git python39 py39-pip py39-gdbm py39-sqlite3 py39-tox
-    - ln -s /usr/local/bin/python3.9 /usr/local/bin/python
+    - pkg install -y git python39 py39-pip py39-gdbm py39-sqlite3 py39-tox # py39-pipx
+    # The pipx port for 2022Q3 is outdated/broken, we need the latest
     - pip install -U pipx
-      # In 2022Q2, the version or pipx in freebsd repos is outdated/broken.
-      # So we need to install with pipx.
-      # Probably it is safe to install py39-pipx directly after Oct/2022.
+      # pipx in freebsd 2022Q3 is outdated/broken, so we obtain it with pip.
+      # Probably it is safe to `pkg install py39-pipx` directly after Oct/2022.
+    - ln -s /usr/local/bin/python3.9 /usr/local/bin/python
   <<: *test-template
 
-# windows_task:
-#   name: test (Windows - 3.9.10)
-#   windows_container:
-#     image: "cirrusci/windowsservercore:2019"
-#     os_version: 2019
-#   env:
-#     CIRRUS_SHELL: bash
-#     PATH: /c/Python39:/c/Python39/Scripts:${PATH}
-#   install_script:
-#     # Activate long file paths to avoid some errors
-#     - ps: New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
-#     - choco install -y --no-progress python3 --version=3.9.10 --params "/NoLockdown"
-#     - pip install --upgrade certifi
-#     - python -m pip install -U pip tox pipx
-#   <<: *test-template
+windows_task:
+  name: test (Windows - 3.9.10)
+  windows_container:
+    image: "cirrusci/windowsservercore:2019"
+    os_version: 2019
+  env:
+    CIRRUS_SHELL: bash
+    PATH: /c/Python39:/c/Python39/Scripts:${PATH}
+  install_script:
+    # Activate long file paths to avoid some errors
+    - ps: New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
+    - choco install -y --no-progress python3 --version=3.9.10 --params "/NoLockdown"
+    - pip install --upgrade certifi
+    - python -m pip install -U pip tox pipx
+  <<: *test-template
 
-# finalize_task:
-#   container: {image: "python:3.10-bullseye"}
-#   depends_on: [test]
-#   <<: *task-template
-#   install_script: pip install coveralls
-#   finalize_coverage_script: coveralls --finish
+finalize_task:
+  container: {image: "python:3.10-bullseye"}
+  depends_on: [test]
+  <<: *task-template
+  install_script: pip install coveralls
+  finalize_coverage_script: coveralls --finish
 
-# linkcheck_task:
-#   name: linkcheck (Linux - 3.10)
-#   container: {image: "python:3.10-bullseye"}
-#   depends_on: [finalize]
-#   allow_failures: true
-#   dist_cache: {folder: dist, fingerprint_script: echo $CIRRUS_BUILD_ID}  # download
-#   <<: *task-template
-#   install_script: pip install tox
-#   linkcheck_script: tox --installpkg dist/*.whl -e linkcheck -- -q
+linkcheck_task:
+  name: linkcheck (Linux - 3.10)
+  container: {image: "python:3.10-bullseye"}
+  depends_on: [finalize]
+  allow_failures: true
+  dist_cache: {folder: dist, fingerprint_script: echo $CIRRUS_BUILD_ID}  # download
+  <<: *task-template
+  install_script: pip install tox
+  linkcheck_script: tox --installpkg dist/*.whl -e linkcheck -- -q
 
-# publish_task:
-#   name: publish (Linux - 3.10)
-#   container: {image: "python:3.10-bullseye"}
-#   depends_on: [check, build, test]
-#   only_if: $CIRRUS_TAG =~ 'v\d.*' && $CIRRUS_USER_PERMISSION == "admin"
-#   <<: *task-template
-#   dist_cache: {folder: dist, fingerprint_script: echo $CIRRUS_BUILD_ID}  # download
-#   env:
-#     TWINE_REPOSITORY: testpypi
-#     TWINE_USERNAME: __token__
-#     TWINE_PASSWORD: $PYPI_TOKEN
-#     # See: https://cirrus-ci.org/guide/writing-tasks/#encrypted-variables
-#   install_script: pip install tox
-#   publish_script:
-#     - ls dist/*
-#     - tox -e publish
+publish_task:
+  name: publish (Linux - 3.10)
+  container: {image: "python:3.10-bullseye"}
+  depends_on: [check, build, test]
+  only_if: $CIRRUS_TAG =~ 'v\d.*' && $CIRRUS_USER_PERMISSION == "admin"
+  <<: *task-template
+  dist_cache: {folder: dist, fingerprint_script: echo $CIRRUS_BUILD_ID}  # download
+  env:
+    TWINE_REPOSITORY: testpypi
+    TWINE_USERNAME: __token__
+    TWINE_PASSWORD: $PYPI_TOKEN
+    # See: https://cirrus-ci.org/guide/writing-tasks/#encrypted-variables
+  install_script: pip install tox
+  publish_script:
+    - ls dist/*
+    - tox -e publish

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -130,7 +130,6 @@ freebsd_task:
   install_script:
     - pkg remove -y python lang/python
     - pkg install -y git python39 py39-pip py39-gdbm py39-sqlite3 py39-tox # py39-pipx
-    # The pipx port for 2022Q3 is outdated/broken, we need the latest
     - pip install -U pipx
       # pipx in freebsd 2022Q3 is outdated/broken, so we obtain it with pip.
       # Probably it is safe to `pkg install py39-pipx` directly after Oct/2022.

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -135,18 +135,22 @@ freebsd_task:
     - pkg remove -y python lang/python
     - pkg install -y git python39 py39-pip py39-gdbm py39-sqlite3 py39-tox
     - ln -s /usr/local/bin/python3.9 /usr/local/bin/python
-    # Install pipx from source since the latest pre-compiled version is outdated.
-    # Obs.: Probably it is safe to install py39-pipx directly after Oct/2022.
-    - portsnap fetch --interactive
-      # Unfortunatelly we cannot ommit the `--interactive` config here,
-      # otherwise the random delay can be too big to afford.
-      # On the bright side, the CI should run on demand, so the likely hood
-      # of multiple jobs hitting the FreeBSD server at the same time is small.
-    - portsnap extract devel/py-pipx
-    - cd /usr/ports/devel/py-pipx
-    - cat Makefile
-    - make
-    - make reinstall clean
+    - pkg update -f
+    - pkg search pipx
+    - pkg search -o pipx
+    - pkg install -y py39-pipx-1.1.0_1
+    # # Install pipx from source since the latest pre-compiled version is outdated.
+    # # Obs.: Probably it is safe to install py39-pipx directly after Oct/2022.
+    # - portsnap fetch --interactive
+    #   # Unfortunatelly we cannot ommit the `--interactive` config here,
+    #   # otherwise the random delay can be too big to afford.
+    #   # On the bright side, the CI should run on demand, so the likely hood
+    #   # of multiple jobs hitting the FreeBSD server at the same time is small.
+    # - portsnap extract devel/py-pipx
+    # - cd /usr/ports/devel/py-pipx
+    # - cat Makefile
+    # - make
+    # - make reinstall clean
   <<: *test-template
 
 # windows_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -129,8 +129,9 @@ freebsd_task:
   freebsd_instance: {image_family: freebsd-13-1}
   install_script:
     - pkg remove -y python lang/python
-    - pkg install -y git python39 py39-pip py39-gdbm py39-sqlite3 py39-tox py39-pipx
+    - pkg install -y git python39 py39-pip py39-gdbm py39-sqlite3 py39-tox
     - ln -s /usr/local/bin/python3.9 /usr/local/bin/python
+    - python -m pip install pipx  # workaround for py39-pipx
   <<: *test-template
 
 windows_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -128,6 +128,7 @@ freebsd_task:
   name: test (freebsd - 3.9)
   freebsd_instance: {image_family: freebsd-13-1}
   install_script:
+    - portsnap fetch update
     - pkg update -f
     - pkg remove -y python lang/python
     - pkg install -y git python39 py39-pip py39-gdbm py39-sqlite3 py39-tox py39-pipx

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -133,29 +133,13 @@ freebsd_task:
     DEFAULT_VERSIONS: python=3.9 python3=3.9
   install_script:
     # The pipx port for 2022Q3 is outdated/broken, we need the latest
-    - mkdir -p /usr/local/etc/pkg/repos/
-    - cp /etc/pkg/FreeBSD.conf /usr/local/etc/pkg/repos/FreeBSD.conf
-    - sed -i .bkp 's/quarterly/latest/' /usr/local/etc/pkg/repos/FreeBSD.conf
-    - cat /usr/local/etc/pkg/repos/FreeBSD.conf
     - pkg remove -y python lang/python
     - pkg install -y git python39 py39-pip py39-gdbm py39-sqlite3 py39-tox
     - ln -s /usr/local/bin/python3.9 /usr/local/bin/python
-    - pkg update -f
-    - pkg search pipx
-    - pkg search -o pipx
-    - pkg install -y py39-pipx-0.16.3
-    # # Install pipx from source since the latest pre-compiled version is outdated.
-    # # Obs.: Probably it is safe to install py39-pipx directly after Oct/2022.
-    # - portsnap fetch --interactive
-    #   # Unfortunatelly we cannot ommit the `--interactive` config here,
-    #   # otherwise the random delay can be too big to afford.
-    #   # On the bright side, the CI should run on demand, so the likely hood
-    #   # of multiple jobs hitting the FreeBSD server at the same time is small.
-    # - portsnap extract devel/py-pipx
-    # - cd /usr/ports/devel/py-pipx
-    # - cat Makefile
-    # - make
-    # - make reinstall clean
+    - pip install -U pipx
+      # In 2022Q2, the version or pipx in freebsd repos is outdated/broken.
+      # So we need to install with pipx.
+      # Probably it is safe to install py39-pipx directly after Oct/2022.
   <<: *test-template
 
 # windows_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -128,7 +128,7 @@ freebsd_task:
   name: test (freebsd - 3.9)
   freebsd_instance: {image_family: freebsd-13-1}
   install_script:
-    - portsnap auto
+    - portsnap fetch --interactive update
     - pkg update -f
     - pkg remove -y python lang/python
     - pkg install -y git python39 py39-pip py39-gdbm py39-sqlite3 py39-tox py39-pipx

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -133,13 +133,8 @@ freebsd_task:
     - ln -s /usr/local/bin/python3.9 /usr/local/bin/python
     # Install pipx from source since the latest pre-compiled version is outdated.
     # Obs.: Probably it is safe to install py39-pipx directly after Oct/2022.
-    - portsnap auto --interactive
-      # Unfortunatelly we cannot ommit the `--interactive` config here,
-      # otherwise the random delay can be too big to afford.
-      # On the bright side, the CI should run on demand, so the likely hood
-      # of multiple jobs hitting the FreeBSD server at the same time is small.
     - cd /usr/ports/devel/py-pipx
-    - cat Makefile
+    - make fetch-recursive
     - make FLAVOR=py39
     - make FLAVOR=py39 install clean
   <<: *test-template

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -134,7 +134,8 @@ freebsd_task:
     # Install pipx from source since the latest pre-compiled version is outdated.
     # Obs.: Probably it is safe to install py39-pipx directly after Oct/2022.
     - cd /usr/ports/devel/py-pipx
-    - make fetch-recursive
+    - make fetch
+    - cat Makefile
     - make FLAVOR=py39
     - make FLAVOR=py39 reinstall clean
   <<: *test-template

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -143,7 +143,7 @@ freebsd_task:
     - pkg update -f
     - pkg search pipx
     - pkg search -o pipx
-    - pkg install -y py39-pipx
+    - pkg install -y py39-pipx-0.16.3
     # # Install pipx from source since the latest pre-compiled version is outdated.
     # # Obs.: Probably it is safe to install py39-pipx directly after Oct/2022.
     # - portsnap fetch --interactive

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -133,8 +133,9 @@ freebsd_task:
     - ln -s /usr/local/bin/python3.9 /usr/local/bin/python
     # Install pipx from source since the latest pre-compiled version is outdated.
     # Obs.: Probably it is safe to install py39-pipx directly after Oct/2022.
-    - cd /usr/ports/devel/py-pipx
+    - cd /usr/ports/devel/
     - make fetch
+    - cd /usr/ports/devel/py-pipx
     - cat Makefile
     - make FLAVOR=py39
     - make FLAVOR=py39 reinstall clean

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -125,12 +125,12 @@ macos_task:
   <<: *test-template
 
 freebsd_task:
-  name: test (freebsd - 3.8)
-  freebsd_instance: {image_family: freebsd-13-0}
+  name: test (freebsd - 3.9)
+  freebsd_instance: {image_family: freebsd-13-1}
   install_script:
     - pkg remove -y python lang/python
-    - pkg install -y git python38 py38-pip py38-gdbm py38-sqlite3 py38-tox py38-pipx
-    - ln -s /usr/local/bin/python3.8 /usr/local/bin/python
+    - pkg install -y git python39 py39-pip py39-gdbm py39-sqlite3 py39-tox py39-pipx
+    - ln -s /usr/local/bin/python3.9 /usr/local/bin/python
   <<: *test-template
 
 windows_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -141,8 +141,9 @@ freebsd_task:
     - portsnap extract devel/py-pipx
     - cd /usr/ports/devel/py-pipx
     - cat Makefile
-    - make PYTHON_PKGNAMEPREFIX=py39- FLAVOR=py39
-    - make PYTHON_PKGNAMEPREFIX=py39- FLAVOR=py39 reinstall clean
+    - sed -i "s/python:3.6+/python:3.9/g" Makefile
+    - make PY_FLAVOR=3.9 FLAVOR=py39
+    - make PY_FLAVOR=3.9 FLAVOR=py39 reinstall clean
   <<: *test-template
 
 # windows_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -141,7 +141,8 @@ freebsd_task:
     - portsnap extract devel/py-pipx
     - cd /usr/ports/devel/py-pipx
     - cat Makefile
-    - sed -i "s/python:3.6+/python:3.9/g" Makefile
+    - sed -i .bkp 's/python:3.6+/python:3.9/' Makefile
+    - cat Makefile
     - make PY_FLAVOR=3.9 FLAVOR=py39
     - make PY_FLAVOR=3.9 FLAVOR=py39 reinstall clean
   <<: *test-template

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -76,53 +76,53 @@ build_task:
   install_script: pip install tox
   build_script: tox -e clean,build
 
-check_task:
-  name: check (Linux - 3.10)
-  alias: check
-  depends_on: [build]
-  container: {image: "python:3.10-bullseye"}  # most recent => better types
-  dist_cache: {folder: dist, fingerprint_script: echo $CIRRUS_BUILD_ID}  # download
-  <<: *task-template
-  install_script: pip install pre-commit
-  check_script:
-    - pre-commit run --all-files --show-diff-on-failure --color always
-    # - tox -e typecheck
+# check_task:
+#   name: check (Linux - 3.10)
+#   alias: check
+#   depends_on: [build]
+#   container: {image: "python:3.10-bullseye"}  # most recent => better types
+#   dist_cache: {folder: dist, fingerprint_script: echo $CIRRUS_BUILD_ID}  # download
+#   <<: *task-template
+#   install_script: pip install pre-commit
+#   check_script:
+#     - pre-commit run --all-files --show-diff-on-failure --color always
+#     # - tox -e typecheck
 
-linux_task:
-  matrix:
-    - name: test (Linux - 3.6)
-      container: {image: "python:3.6-bullseye"}
-      allow_failures: true  # EoL
-    - name: test (Linux - 3.7)
-      container: {image: "python:3.7-bullseye"}
-    - name: test (Linux - 3.8)
-      container: {image: "python:3.8-bullseye"}
-    - name: test (Linux - 3.9)
-      container: {image: "python:3.9-bullseye"}
-    - name: test (Linux - 3.10)
-      container: {image: "python:3.10-bullseye"}
-    - name: test (Linux - 3.11)
-      container: {image: "python:3.11-rc-bullseye"}
-      allow_failures: true  # Experimental
-  install_script:
-    - python -m pip install --upgrade pip tox pipx
-  <<: *test-template
+# linux_task:
+#   matrix:
+#     - name: test (Linux - 3.6)
+#       container: {image: "python:3.6-bullseye"}
+#       allow_failures: true  # EoL
+#     - name: test (Linux - 3.7)
+#       container: {image: "python:3.7-bullseye"}
+#     - name: test (Linux - 3.8)
+#       container: {image: "python:3.8-bullseye"}
+#     - name: test (Linux - 3.9)
+#       container: {image: "python:3.9-bullseye"}
+#     - name: test (Linux - 3.10)
+#       container: {image: "python:3.10-bullseye"}
+#     - name: test (Linux - 3.11)
+#       container: {image: "python:3.11-rc-bullseye"}
+#       allow_failures: true  # Experimental
+#   install_script:
+#     - python -m pip install --upgrade pip tox pipx
+#   <<: *test-template
 
-mamba_task:
-  name: test (Linux - mambaforge)
-  container: {image: "condaforge/mambaforge"}
-  install_script:  # Overwrite template
-    - mamba install -y pip tox pipx
-  <<: *test-template
+# mamba_task:
+#   name: test (Linux - mambaforge)
+#   container: {image: "condaforge/mambaforge"}
+#   install_script:  # Overwrite template
+#     - mamba install -y pip tox pipx
+#   <<: *test-template
 
-macos_task:
-  name: test (macOS - brew)
-  macos_instance: {image: "big-sur-xcode"}
-  brew_cache: {folder: "$HOME/Library/Caches/Homebrew"}
-  install_script: brew install python tox pipx
-  env:
-    PATH: "/usr/local/opt/python/libexec/bin:${PATH}"
-  <<: *test-template
+# macos_task:
+#   name: test (macOS - brew)
+#   macos_instance: {image: "big-sur-xcode"}
+#   brew_cache: {folder: "$HOME/Library/Caches/Homebrew"}
+#   install_script: brew install python tox pipx
+#   env:
+#     PATH: "/usr/local/opt/python/libexec/bin:${PATH}"
+#   <<: *test-template
 
 freebsd_task:
   name: test (freebsd - 3.9)
@@ -135,52 +135,52 @@ freebsd_task:
     - ln -s /usr/local/bin/python3.9 /usr/local/bin/python
   <<: *test-template
 
-windows_task:
-  name: test (Windows - 3.9.10)
-  windows_container:
-    image: "cirrusci/windowsservercore:2019"
-    os_version: 2019
-  env:
-    CIRRUS_SHELL: bash
-    PATH: /c/Python39:/c/Python39/Scripts:${PATH}
-  install_script:
-    # Activate long file paths to avoid some errors
-    - ps: New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
-    - choco install -y --no-progress python3 --version=3.9.10 --params "/NoLockdown"
-    - pip install --upgrade certifi
-    - python -m pip install -U pip tox pipx
-  <<: *test-template
+# windows_task:
+#   name: test (Windows - 3.9.10)
+#   windows_container:
+#     image: "cirrusci/windowsservercore:2019"
+#     os_version: 2019
+#   env:
+#     CIRRUS_SHELL: bash
+#     PATH: /c/Python39:/c/Python39/Scripts:${PATH}
+#   install_script:
+#     # Activate long file paths to avoid some errors
+#     - ps: New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
+#     - choco install -y --no-progress python3 --version=3.9.10 --params "/NoLockdown"
+#     - pip install --upgrade certifi
+#     - python -m pip install -U pip tox pipx
+#   <<: *test-template
 
-finalize_task:
-  container: {image: "python:3.10-bullseye"}
-  depends_on: [test]
-  <<: *task-template
-  install_script: pip install coveralls
-  finalize_coverage_script: coveralls --finish
+# finalize_task:
+#   container: {image: "python:3.10-bullseye"}
+#   depends_on: [test]
+#   <<: *task-template
+#   install_script: pip install coveralls
+#   finalize_coverage_script: coveralls --finish
 
-linkcheck_task:
-  name: linkcheck (Linux - 3.10)
-  container: {image: "python:3.10-bullseye"}
-  depends_on: [finalize]
-  allow_failures: true
-  dist_cache: {folder: dist, fingerprint_script: echo $CIRRUS_BUILD_ID}  # download
-  <<: *task-template
-  install_script: pip install tox
-  linkcheck_script: tox --installpkg dist/*.whl -e linkcheck -- -q
+# linkcheck_task:
+#   name: linkcheck (Linux - 3.10)
+#   container: {image: "python:3.10-bullseye"}
+#   depends_on: [finalize]
+#   allow_failures: true
+#   dist_cache: {folder: dist, fingerprint_script: echo $CIRRUS_BUILD_ID}  # download
+#   <<: *task-template
+#   install_script: pip install tox
+#   linkcheck_script: tox --installpkg dist/*.whl -e linkcheck -- -q
 
-publish_task:
-  name: publish (Linux - 3.10)
-  container: {image: "python:3.10-bullseye"}
-  depends_on: [check, build, test]
-  only_if: $CIRRUS_TAG =~ 'v\d.*' && $CIRRUS_USER_PERMISSION == "admin"
-  <<: *task-template
-  dist_cache: {folder: dist, fingerprint_script: echo $CIRRUS_BUILD_ID}  # download
-  env:
-    TWINE_REPOSITORY: testpypi
-    TWINE_USERNAME: __token__
-    TWINE_PASSWORD: $PYPI_TOKEN
-    # See: https://cirrus-ci.org/guide/writing-tasks/#encrypted-variables
-  install_script: pip install tox
-  publish_script:
-    - ls dist/*
-    - tox -e publish
+# publish_task:
+#   name: publish (Linux - 3.10)
+#   container: {image: "python:3.10-bullseye"}
+#   depends_on: [check, build, test]
+#   only_if: $CIRRUS_TAG =~ 'v\d.*' && $CIRRUS_USER_PERMISSION == "admin"
+#   <<: *task-template
+#   dist_cache: {folder: dist, fingerprint_script: echo $CIRRUS_BUILD_ID}  # download
+#   env:
+#     TWINE_REPOSITORY: testpypi
+#     TWINE_USERNAME: __token__
+#     TWINE_PASSWORD: $PYPI_TOKEN
+#     # See: https://cirrus-ci.org/guide/writing-tasks/#encrypted-variables
+#   install_script: pip install tox
+#   publish_script:
+#     - ls dist/*
+#     - tox -e publish


### PR DESCRIPTION
I started noticing that recently freebsd builds started failing.
It seems that the best course of action is to update the packages from py38 to py39.

Unfortunately there still a bug in FreeBSD `pipx` native installation for `py39-pipx`.

For the time being we can use this as a workaround.